### PR TITLE
Adding an override for selecting how we obtain an IP for the created VM

### DIFF
--- a/builder/xenserver/common/common_config.go
+++ b/builder/xenserver/common/common_config.go
@@ -50,6 +50,7 @@ type CommonConfig struct {
 	OutputDir string `mapstructure:"output_directory"`
 	Format    string `mapstructure:"format"`
 	KeepVM    string `mapstructure:"keep_vm"`
+    IPGetter  string `mapstructure:"ip_getter"`
 }
 
 func (c *CommonConfig) Prepare(t *packer.ConfigTemplate, pc *common.PackerConfig) []error {
@@ -123,6 +124,10 @@ func (c *CommonConfig) Prepare(t *packer.ConfigTemplate, pc *common.PackerConfig
 		c.KeepVM = "never"
 	}
 
+    if c.IPGetter == "" {
+        c.IPGetter = "auto"
+    }
+
 	// Template substitution
 
 	templates := map[string]*string{
@@ -142,6 +147,7 @@ func (c *CommonConfig) Prepare(t *packer.ConfigTemplate, pc *common.PackerConfig
 		"output_directory": &c.OutputDir,
 		"format":           &c.Format,
 		"keep_vm":          &c.KeepVM,
+        "ip_getter":        &c.IPGetter,
 	}
 	for i := range c.FloppyFiles {
 		templates[fmt.Sprintf("floppy_files[%d]", i)] = &c.FloppyFiles[i]
@@ -224,6 +230,12 @@ func (c *CommonConfig) Prepare(t *packer.ConfigTemplate, pc *common.PackerConfig
 	default:
 		errs = append(errs, errors.New("keep_vm must be one of 'always', 'never', 'on_success'"))
 	}
+
+    switch c.IPGetter {
+    case "auto", "tools", "http":
+    default:
+        errs = append(errs, errors.New("ip_getter must be one of 'auto', 'tools', 'http'"))
+    }
 
 	return errs
 }


### PR DESCRIPTION
In particular this helps disable HTTP snooping where the installers IP may differ from the IP obtained on firstboot.

Signed-off-by: Rob Dobson <rob.dobson@citrix.com>