### PR TITLE
Eject floppy and installation ISO after the VM has been provisioned.

### DIFF
--- a/builder/xenserver/iso/builder.go
+++ b/builder/xenserver/iso/builder.go
@@ -303,24 +303,16 @@ func (self *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (pa
 			SSHConfig:      xscommon.SSHConfig,
 			SSHWaitTimeout: self.config.SSHWaitTimeout,
 		},
-		new(xscommon.StepShutdown),
-		&xscommon.StepDetachVdi{
-			VdiUuidKey: "floppy_vdi_uuid",
-		},
-		&xscommon.StepDetachVdi{
-			VdiUuidKey: "iso_vdi_uuid",
-		},
-		new(xscommon.StepStartVmPaused),
-		new(xscommon.StepBootWait),
-		&common.StepConnectSSH{
-			SSHAddress:     xscommon.SSHLocalAddress,
-			SSHConfig:      xscommon.SSHConfig,
-			SSHWaitTimeout: self.config.SSHWaitTimeout,
-		},
 		new(common.StepProvision),
 		new(xscommon.StepShutdown),
 		&xscommon.StepDetachVdi{
+			VdiUuidKey: "iso_vdi_uuid",
+		},
+		&xscommon.StepDetachVdi{
 			VdiUuidKey: "tools_vdi_uuid",
+		},
+		&xscommon.StepDetachVdi{
+			VdiUuidKey: "floppy_vdi_uuid",
 		},
 		new(xscommon.StepExport),
 	}


### PR DESCRIPTION
To work around an issue in the PV drivers for Windows, the floppy and
installation ISO were removed before restarting the guest. This was due
to the drivers bluescreening on a failed assert of the presence of a
floppy disk.

Now that behaviour has been fixed, the builder should behave in the
expected way, and not introduce an extra shutdown/restart.

Signed-off-by: Rob Dobson rob.dobson@citrix.com
