### PR TITLE
Refactoring to build with upstream core packer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
   # Test with the first and the latest go release - to ensure compatibility
-  - 1
+  - 1.2
   - release
 script:
   - gofmtresult=$(gofmt -s -l .); if [[ -n $gofmtresult ]]; then echo -e "Please run \"gofmt -s -w .\" before committing for the below:\n$gofmtresult"; false; fi

--- a/builder/xenserver/common/ssh_config.go
+++ b/builder/xenserver/common/ssh_config.go
@@ -1,0 +1,48 @@
+package common
+
+import (
+	"errors"
+	"time"
+
+	"github.com/mitchellh/packer/helper/communicator"
+	"github.com/mitchellh/packer/template/interpolate"
+)
+
+type SSHConfig struct {
+	Comm communicator.Config `mapstructure:",squash"`
+
+	SSHHostPortMin    uint `mapstructure:"ssh_host_port_min"`
+	SSHHostPortMax    uint `mapstructure:"ssh_host_port_max"`
+	SSHSkipNatMapping bool `mapstructure:"ssh_skip_nat_mapping"`
+
+	// These are deprecated, but we keep them around for BC
+	// TODO(@mitchellh): remove
+	SSHKeyPath     string        `mapstructure:"ssh_key_path"`
+	SSHWaitTimeout time.Duration `mapstructure:"ssh_wait_timeout"`
+}
+
+func (c *SSHConfig) Prepare(ctx *interpolate.Context) []error {
+	if c.SSHHostPortMin == 0 {
+		c.SSHHostPortMin = 2222
+	}
+
+	if c.SSHHostPortMax == 0 {
+		c.SSHHostPortMax = 4444
+	}
+
+	// TODO: backwards compatibility, write fixer instead
+	if c.SSHKeyPath != "" {
+		c.Comm.SSHPrivateKey = c.SSHKeyPath
+	}
+	if c.SSHWaitTimeout != 0 {
+		c.Comm.SSHTimeout = c.SSHWaitTimeout
+	}
+
+	errs := c.Comm.Prepare(ctx)
+	if c.SSHHostPortMin > c.SSHHostPortMax {
+		errs = append(errs,
+			errors.New("ssh_host_port_min must be less than ssh_host_port_max"))
+	}
+
+	return errs
+}

--- a/builder/xenserver/iso/builder.go
+++ b/builder/xenserver/iso/builder.go
@@ -64,6 +64,7 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, retErr error
 
 	errs = packer.MultiErrorAppend(
 		errs, self.config.CommonConfig.Prepare(&self.config.ctx, &self.config.PackerConfig)...)
+	errs = packer.MultiErrorAppend(errs, self.config.SSHConfig.Prepare(&self.config.ctx)...)
 
 	// Set default values
 

--- a/builder/xenserver/iso/builder.go
+++ b/builder/xenserver/iso/builder.go
@@ -10,7 +10,10 @@ import (
 
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/common"
+	"github.com/mitchellh/packer/helper/communicator"
+	hconfig "github.com/mitchellh/packer/helper/config"
 	"github.com/mitchellh/packer/packer"
+	"github.com/mitchellh/packer/template/interpolate"
 	xscommon "github.com/rdobson/packer-builder-xenserver/builder/xenserver/common"
 	xsclient "github.com/xenserver/go-xenserver-client"
 )
@@ -34,7 +37,7 @@ type config struct {
 	RawInstallTimeout string        `mapstructure:"install_timeout"`
 	InstallTimeout    time.Duration ``
 
-	tpl *packer.ConfigTemplate
+	ctx interpolate.Context
 }
 
 type Builder struct {
@@ -44,20 +47,23 @@ type Builder struct {
 
 func (self *Builder) Prepare(raws ...interface{}) (params []string, retErr error) {
 
-	md, err := common.DecodeConfig(&self.config, raws...)
+	var errs *packer.MultiError
+
+	err := hconfig.Decode(&self.config, &hconfig.DecodeOpts{
+		Interpolate: true,
+		InterpolateFilter: &interpolate.RenderFilter{
+			Exclude: []string{
+				"boot_command",
+			},
+		},
+	}, raws...)
+
 	if err != nil {
-		return nil, err
+		packer.MultiErrorAppend(errs, err)
 	}
 
-	self.config.tpl, err = packer.NewConfigTemplate()
-	if err != nil {
-		return nil, err
-	}
-	self.config.tpl.UserVars = self.config.PackerUserVars
-
-	errs := common.CheckUnusedConfig(md)
 	errs = packer.MultiErrorAppend(
-		errs, self.config.CommonConfig.Prepare(self.config.tpl, &self.config.PackerConfig)...)
+		errs, self.config.CommonConfig.Prepare(&self.config.ctx, &self.config.PackerConfig)...)
 
 	// Set default values
 
@@ -101,14 +107,6 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, retErr error
 	}
 	for i := range self.config.ISOUrls {
 		templates[fmt.Sprintf("iso_urls[%d]", i)] = &self.config.ISOUrls[i]
-	}
-
-	for n, ptr := range templates {
-		var err error
-		*ptr, err = self.config.tpl.Process(*ptr, nil)
-		if err != nil {
-			errs = packer.MultiErrorAppend(errs, fmt.Errorf("Error processing %s: %s", n, err))
-		}
 	}
 
 	// Validation
@@ -285,7 +283,7 @@ func (self *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (pa
 		},
 		new(xscommon.StepBootWait),
 		&xscommon.StepTypeBootCommand{
-			Tpl: self.config.tpl,
+			Ctx: self.config.ctx,
 		},
 		&xscommon.StepWaitForIP{
 			Chan:    httpReqChan,
@@ -298,10 +296,11 @@ func (self *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (pa
 			HostPortMax: self.config.HostPortMax,
 			ResultKey:   "local_ssh_port",
 		},
-		&common.StepConnectSSH{
-			SSHAddress:     xscommon.SSHLocalAddress,
-			SSHConfig:      xscommon.SSHConfig,
-			SSHWaitTimeout: self.config.SSHWaitTimeout,
+		&communicator.StepConnect{
+			Config:    &self.config.SSHConfig.Comm,
+			Host:      xscommon.CommHost,
+			SSHConfig: xscommon.SSHConfigFunc(self.config.CommonConfig.SSHConfig),
+			SSHPort:   xscommon.SSHPort,
 		},
 		new(xscommon.StepShutdown),
 		&xscommon.StepDetachVdi{
@@ -312,10 +311,11 @@ func (self *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (pa
 		},
 		new(xscommon.StepStartVmPaused),
 		new(xscommon.StepBootWait),
-		&common.StepConnectSSH{
-			SSHAddress:     xscommon.SSHLocalAddress,
-			SSHConfig:      xscommon.SSHConfig,
-			SSHWaitTimeout: self.config.SSHWaitTimeout,
+		&communicator.StepConnectSSH{
+			Config:    &self.config.SSHConfig.Comm,
+			Host:      xscommon.CommHost,
+			SSHConfig: xscommon.SSHConfigFunc(self.config.CommonConfig.SSHConfig),
+			SSHPort:   xscommon.SSHPort,
 		},
 		new(common.StepProvision),
 		new(xscommon.StepShutdown),


### PR DESCRIPTION
Since the plugin was written earlier this year, there have been a number of refactoring efforts upstream modifying:
- Template manipulation
- Generalising connection type

The bulk of this patch is transitioning to use the interpolate library to simplifying the template parsing code.

Signed-off-by: Rob Dobson rob.dobson@citrix.com
