### PR TITLE
Add option for static IP

### DIFF
--- a/builder/xenserver/common/common_config.go
+++ b/builder/xenserver/common/common_config.go
@@ -45,6 +45,7 @@ type CommonConfig struct {
 	SSHPassword string `mapstructure:"ssh_password"`
 	SSHPort     uint   `mapstructure:"ssh_port"`
 	SSHUser     string `mapstructure:"ssh_username"`
+	SSHHost     string `mapstructure:"ssh_host"`
 	SSHConfig   `mapstructure:",squash"`
 
 	RawSSHWaitTimeout string `mapstructure:"ssh_wait_timeout"`
@@ -196,9 +197,9 @@ func (c *CommonConfig) Prepare(ctx *interpolate.Context, pc *common.PackerConfig
 	}
 
 	switch c.IPGetter {
-	case "auto", "tools", "http":
+	case "auto", "tools", "http", "static":
 	default:
-		errs = append(errs, errors.New("ip_getter must be one of 'auto', 'tools', 'http'"))
+		errs = append(errs, errors.New("ip_getter must be one of 'auto', 'tools', 'http', 'static'"))
 	}
 
 	return errs

--- a/builder/xenserver/common/step_wait_for_ip.go
+++ b/builder/xenserver/common/step_wait_for_ip.go
@@ -66,6 +66,12 @@ func (self *StepWaitForIP) Run(state multistep.StateBag) multistep.StepAction {
 
 			}
 
+            if config.IPGetter == "static" {
+                ip = config.SSHHost
+                ui.Message(fmt.Sprintf("Static IP is defined as '%s'", ip))
+                return true,nil
+            }
+
 			return false, nil
 		},
 	}.Wait(state)

--- a/docs/builders/xenserver-iso.html.markdown
+++ b/docs/builders/xenserver-iso.html.markdown
@@ -180,6 +180,10 @@ each category, the available options are alphabetized and described.
   If it doesn't shut down in this time, it is an error. By default, the timeout
   is "5m", or five minutes.
 
+* `ssh_host` - The IP address to use for the virtual machine.  This is useful for
+  building in an environment where static IP assignment must be used.  The
+  `ip_getter` option must also be set to `static`.
+
 * `ssh_host_port_min` and `ssh_host_port_max` (integer) - The minimum and
   maximum port to use for the SSH port on the host machine which is forwarded
   to the SSH port on the guest machine. Because Packer often runs in parallel,


### PR DESCRIPTION
Rob,

I needed to build in a XEN Server in an environment where I have to use static IP.  I added the ssh_host option and a setting for ip_getter that bypasses the VM IP discovery and uses the given value.

