### PR TITLE
Fix #93 - context not being set on StepTypeBootCommand

### DIFF
--- a/builder/xenserver/iso/builder.go
+++ b/builder/xenserver/iso/builder.go
@@ -52,6 +52,9 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, retErr error
 
 	var errs *packer.MultiError
 
+	context, _ := hconfig.DetectContext(raws...)
+	self.config.ctx = *context
+
 	err := hconfig.Decode(&self.config, &hconfig.DecodeOpts{
 		Interpolate: true,
 		InterpolateFilter: &interpolate.RenderFilter{

--- a/builder/xenserver/xva/builder.go
+++ b/builder/xenserver/xva/builder.go
@@ -37,6 +37,9 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, retErr error
 
 	var errs *packer.MultiError
 
+	context, _ := hconfig.DetectContext(raws...)
+	self.config.ctx = *context
+
 	err := hconfig.Decode(&self.config, &hconfig.DecodeOpts{
 		Interpolate: true,
 		InterpolateFilter: &interpolate.RenderFilter{


### PR DESCRIPTION
The issue is due to empty context being set as config.ctx in the builder. So the interpolate function used inside StepTypeBootCommand has no knowledge of the UserVariables.

This commit fixes the issue and so the issue #93 