### PR TITLE
Fix directory containing cross-compiled code.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,7 @@ IFS=$OLDIFS
 
 # Copy our OS/Arch to the bin/ directory
 echo "==> Copying binaries for this platform..."
-DEV_PLATFORM="./pkg/$(go env GOOS)_$(go env GOARCH)"
+DEV_PLATFORM="./pkg/${XC_OS}_${XC_ARCH}"
 for F in $(find ${DEV_PLATFORM} -mindepth 1 -maxdepth 1 -type f); do
     cp ${F} bin/
     cp ${F} ${MAIN_GOPATH}/bin/


### PR DESCRIPTION
 Prior to this fix, the build script copied files out of a directory for the host platform; however, the build output directory's name is based on the target platform's directory. This commit corrects the source of the copy of build products.